### PR TITLE
Integrate Auckland Rugby Union data source and refactor services

### DIFF
--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -3,7 +3,7 @@
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'models.dart';
+import 'models.dart'; // Only imports models, does not define them.
 
 class ApiService {
   // --- Headers ---
@@ -205,7 +205,6 @@ class ApiService {
       final response = await http.get(url);
       if (response.statusCode == 200) {
         final body = response.body;
-        // Use a regex to find the buildId from the __NEXT_DATA__ script tag
         final pattern = RegExp(r'"buildId":"([^"]+)"');
         final match = pattern.firstMatch(body);
         if (match != null && match.group(1) != null) {
@@ -217,7 +216,6 @@ class ApiService {
       throw Exception('Failed to find Rugby Union buildId in HTML response.');
     } catch (e) {
       print('Error fetching Rugby Union build ID: $e');
-      // Fallback to the last known working ID as a last resort
       return 'EYwFsoHsI7WQjAopi5hIv';
     }
   }

--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -1,89 +1,132 @@
 // lib/api_service.dart
 
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'package:flutter/material.dart';
 import 'models.dart';
 
 class ApiService {
-  static const String _baseUrl = "http://localhost:9999/api/v2/competition/widget";
-  
+  // --- Headers ---
   static final Map<String, String> _headers = {
     'Content-Type': 'application/json',
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
+    'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
   };
 
-  Map<String, dynamic>? _cachedMetadata;
-  List<Fixture>? _cachedFixtures;
-  Map<String, dynamic>? _cachedPhases;
+  // --- PROXY AND API URLS ---
+  static const String _proxyBaseUrl = "http://localhost:9999";
 
-  static final List<String> _initialCompIdsPayload = [
-    "10362", "10180", "10181", "10182", "10183", "10184", "10113", "10114", "10115", "10116", "10286", "10288", "10394", "10395", "10396", "10401", "10402", "10403", "10045", "10033", "10034", "10041", "11769", "11109", "11110", "11226", "11227", "10197", "10333", "10334", "10335", "10336", "10337", "10340", "10202", "10203", "10204", "10205", "10206", "10821", "9982", "9983", "9995", "9996", "9974", "9975", "9976", "9977", "9978", "9979", "9980", "9981", "10017", "10046", "10047", "10005", "10006", "10124", "10125", "10126", "10292", "10296", "11261", "10121", "10025", "10026", "10035", "10147", "10148", "10341", "10342", "10343", "10137", "10138", "10185", "10186", "10140", "10141", "10190", "10191", "10207", "10208", "10209", "10200", "10257", "10192", "10193", "10194", "10195", "10196", "10305"
-  ];
-  
+  // --- CollegeSport API (via proxy) ---
+  static const String _collegeSportBaseUrl = "$_proxyBaseUrl/collegesport/api/v2/competition/widget";
+  Map<String, dynamic>? _cachedCollegeSportMetadata;
+  List<Fixture>? _cachedCollegeSportFixtures;
+
+  // --- Rugby Union API (partially via proxy) ---
+  static const String _rugbyUnionDataUrl = "$_proxyBaseUrl/aucklandrugby/_next/data/EYwFsoHsI7WQjAopi5hIv/fixtures-results.json";
+  static const String _rugbyUnionApiUrl = "https://rugby-au-cms.graphcdn.app/"; // Direct, as it has CORS enabled
+  Map<String, dynamic>? _cachedRugbyUnionData;
+
+  // --- Shared Data ---
   static const Map<String, String> _sportIcons = {
     'Football': '⚽', 'Basketball': '🏀', 'Tennis': '🎾', 'Cricket': '🏏',
     'Hockey': '🏒', 'Rugby Union': '🏉', 'Volleyball': '🏐', 'Netball': '🥅',
     'Default': '🏅',
   };
 
-  Future<Map<String, dynamic>> _getCompetitionMetadata() async {
-    if (_cachedMetadata != null) {
-      return _cachedMetadata!;
-    }
-    
-    final response = await http.post(
-      Uri.parse('$_baseUrl/metadata/'),
-      headers: _headers,
-      body: json.encode(_initialCompIdsPayload),
-    );
-
-    if (response.statusCode == 200) {
-      _cachedMetadata = json.decode(response.body);
-      return _cachedMetadata!;
-    } else {
-      throw Exception('Failed to load competition metadata');
-    }
-  }
+  // --- PUBLIC METHODS (ORCHESTRATORS) ---
 
   Future<List<Sport>> getSportsForSacredHeart() async {
-    final List<Fixture> fixtures = await getFixtures();
-    final Set<String> sacredHeartSportNames = fixtures.map((f) => f.sport).toSet();
-    final metadata = await _getCompetitionMetadata();
-    final List<dynamic> allSportsData = metadata['Sports'] ?? [];
+    final List<Fixture> allFixtures = await getFixtures();
+    final Set<String> sportNames = allFixtures.map((f) => f.sport).toSet();
+    
+    final List<Sport> sports = sportNames.map((name) {
+      final icon = _sportIcons[name] ?? _sportIcons['Default']!;
+      final id = name.hashCode; 
+      return Sport(id: id, name: name, icon: icon, source: name == 'Rugby Union' ? DataSource.rugbyUnion : DataSource.collegeSport);
+    }).toList();
 
-    final filteredSportsData = allSportsData
-        .where((s) => sacredHeartSportNames.contains(s['Name']))
-        .toList();
+    sports.sort((a, b) => a.name.compareTo(b.name));
+    return sports;
+  }
 
-    return filteredSportsData
-        .map((s) => Sport.fromJson(s, _sportIcons[s['Name']] ?? _sportIcons['Default']!))
-        .toList()
-      ..sort((a, b) => a.name.compareTo(b.name));
+  Future<List<Fixture>> getFixtures({DateTimeRange? dateRange}) async {
+    final results = await Future.wait([
+      _getCollegeSportFixtures(dateRange: dateRange),
+      _getRugbyUnionFixtures(dateRange: dateRange),
+    ]);
+
+    final allFixtures = results.expand((fixtures) => fixtures).toList();
+    return allFixtures;
   }
 
   Future<List<String>> getTeamsForSport(String sportName) async {
-    const String schoolName = "Sacred Heart College (Auckland)";
+    const String schoolName = "Sacred Heart College";
     final List<Fixture> fixtures = await getFixtures();
 
     final teams = fixtures
-        .where((f) => f.sport == sportName)
-        .map((f) => f.homeSchool == schoolName ? f.homeTeam : f.awayTeam)
-        .toSet() 
+        .where((f) => f.sport == sportName && (f.homeSchool.contains(schoolName) || f.awaySchool.contains(schoolName)))
+        .map((f) {
+            if (f.homeSchool.contains(schoolName)) return f.homeTeam;
+            return f.awayTeam;
+        })
+        .toSet()
         .toList()
-      ..sort(); 
+      ..sort();
 
     return teams;
   }
 
-  Future<List<Fixture>> getFixtures({DateTimeRange? dateRange}) async {
-    if (_cachedFixtures != null && dateRange == null) {
-      return _cachedFixtures!;
+  Future<List<Fixture>> getFixturesForTeam(String teamName) async {
+    final allFixtures = await getFixtures(
+        dateRange: DateTimeRange(
+      start: DateTime.now().subtract(const Duration(days: 90)),
+      end: DateTime.now().add(const Duration(days: 90)),
+    ));
+    return allFixtures
+        .where((f) => f.homeTeam == teamName || f.awayTeam == teamName)
+        .toList();
+  }
+
+  Future<List<StandingsTable>> getStandings(String competitionId, int gradeId, DataSource source) async {
+    if (source == DataSource.collegeSport) {
+      return _getCollegeSportStandings(int.parse(competitionId), gradeId);
+    } else {
+      return _getRugbyUnionStandings(competitionId);
+    }
+  }
+
+  // --- PRIVATE METHODS (COLLEGESPORT) ---
+
+  Future<Map<String, dynamic>> _getCollegeSportMetadata() async {
+    if (_cachedCollegeSportMetadata != null) return _cachedCollegeSportMetadata!;
+
+    final payload = [ "10362", "10180", "10181", "10182", "10183", "10184", "10113", "10114", "10115", "10116", "10286", "10288", "10394", "10395", "10396", "10401", "10402", "10403", "10045", "10033", "10034", "10041", "11769", "11109", "11110", "11226", "11227", "10197", "10333", "10334", "10335", "10336", "10337", "10340", "10202", "10203", "10204", "10205", "10206", "10821", "9982", "9983", "9995", "9996", "9974", "9975", "9976", "9977", "9978", "9979", "9980", "9981", "10017", "10046", "10047", "10005", "10006", "10124", "10125", "10126", "10292", "10296", "11261", "10121", "10025", "10026", "10035", "10147", "10148", "10341", "10342", "10343", "10137", "10138", "10185", "10186", "10140", "10141", "10190", "10191", "10207", "10208", "10209", "10200", "10257", "10192", "10193", "10194", "10195", "10196", "10305" ];
+    
+    try {
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/metadata/'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+      if (response.statusCode == 200) {
+        _cachedCollegeSportMetadata = json.decode(response.body);
+        return _cachedCollegeSportMetadata!;
+      }
+    } catch (e) {
+      print("CollegeSport Metadata Error: $e");
+    }
+    return {'Sports': [], 'Competitions': [], 'GradesPerComp': {}, 'OrgsPerComp': {}};
+  }
+
+  Future<List<Fixture>> _getCollegeSportFixtures({DateTimeRange? dateRange}) async {
+    if (_cachedCollegeSportFixtures != null && dateRange == null) {
+      return _cachedCollegeSportFixtures!;
     }
 
-    final metadata = await _getCompetitionMetadata();
-    
-    final List<int> allCompIds = (metadata['Competitions'] as List).map<int>((c) => c['Id']).toList();
+    final metadata = await _getCollegeSportMetadata();
+    if (metadata['Competitions'].isEmpty) return [];
+
+    final allCompIds = (metadata['Competitions'] as List).map<int>((c) => c['Id']).toList();
     final allGradeIds = (metadata['GradesPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((g) => g['Id'] as int).toSet().toList();
     final allOrgIds = (metadata['OrgsPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((o) => o['Id'] as int).toSet().toList();
 
@@ -95,100 +138,169 @@ class ApiService {
       "From": "${fromDate}T00:00:00", "To": "${toDate}T23:59:00"
     };
 
-    final response = await http.post(
-      Uri.parse('$_baseUrl/fixture/Dates'),
-      headers: _headers,
-      body: json.encode(payload),
-    );
+    try {
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/fixture/Dates'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
 
-    if (response.statusCode == 200) {
-      final Map<String, dynamic> decodedData = json.decode(response.body);
-      final List<dynamic> fixtureData = decodedData['Fixtures'] as List<dynamic>? ?? [];
-      
-      const String schoolToFilter = "Sacred Heart College (Auckland)";
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> decodedData = json.decode(response.body);
+        final List<dynamic> fixtureData = decodedData['Fixtures'] as List<dynamic>? ?? [];
+        const String schoolToFilter = "Sacred Heart College (Auckland)";
 
-      final fixtures = fixtureData
-          .where((data) => 
-              data['HomeOrgName'] == schoolToFilter || 
-              data['AwayOrgName'] == schoolToFilter)
-          .map((data) => Fixture.fromJson(data, metadata))
-          .toList();
-
-      if (dateRange == null) {
-        _cachedFixtures = fixtures;
-      }
-      
-      return fixtures;
-    } else {
-      throw Exception('Failed to load fixtures');
-    }
-  }
-
-  Future<List<Fixture>> getFixturesForTeam(String teamName) async {
-    final allFixtures = await getFixtures(
-      dateRange: DateTimeRange(
-        start: DateTime.now().subtract(const Duration(days: 90)),
-        end: DateTime.now().add(const Duration(days: 90)),
-      )
-    );
-    return allFixtures.where((f) => f.homeTeam == teamName || f.awayTeam == teamName).toList();
-  }
-
-  Future<Map<String, dynamic>> _getAvailablePhases() async {
-    if (_cachedPhases != null) return _cachedPhases!;
-
-    final payload = {
-      "CompIds": _initialCompIdsPayload.map(int.parse).toList()
-    };
-
-    final response = await http.post(
-      Uri.parse('$_baseUrl/standings/availablePhases'),
-      headers: _headers,
-      body: json.encode(payload),
-    );
-    if (response.statusCode == 200) {
-        _cachedPhases = json.decode(response.body);
-        return _cachedPhases!;
-    } else {
-        throw Exception('Failed to load available phases. Status: ${response.statusCode}');
-    }
-  }
-
-  // --- MODIFIED ---
-  // This method now uses the correct URL and payload format for fetching standings.
-  Future<List<StandingsTable>> getStandings(int competitionId, int gradeId) async {
-    final phasesData = await _getAvailablePhases();
-    final phasesForComp = phasesData[competitionId.toString()] as List<dynamic>?;
-
-    if (phasesForComp == null || phasesForComp.isEmpty) {
-      return [];
-    }
-
-    final phaseId = phasesForComp.first['Id'];
-
-    // The API expects a POST request with a specific payload.
-    final payload = {
-      "GradeId": gradeId,
-      "PhaseId": phaseId,
-    };
-
-    final response = await http.post( // Changed from GET to POST
-      Uri.parse('$_baseUrl/standings/Phase'), // Corrected URL
-      headers: _headers,
-      body: json.encode(payload), // Added the correct payload
-    );
-
-    if (response.statusCode == 200) {
-        final List<dynamic> decodedData = json.decode(response.body);
-        
-        // The API now returns only the relevant table, so no need to filter by GradeId.
-        final relevantTables = decodedData
-            .map((tableData) => StandingsTable.fromJson(tableData))
+        final fixtures = fixtureData
+            .where((data) =>
+                data['HomeOrgName'] == schoolToFilter ||
+                data['AwayOrgName'] == schoolToFilter)
+            .map((data) => Fixture.fromCollegeSportJson(data, metadata))
             .toList();
 
-        return relevantTables;
-    } else {
-        throw Exception('Failed to load standings for grade $gradeId and phase $phaseId');
+        if (dateRange == null) _cachedCollegeSportFixtures = fixtures;
+        return fixtures;
+      }
+    } catch (e) {
+      print("CollegeSport Fixtures Error: $e");
     }
+    return [];
+  }
+
+  Future<List<StandingsTable>> _getCollegeSportStandings(int competitionId, int gradeId) async {
+    try {
+      final metadata = await _getCollegeSportMetadata();
+      final phasesForComp = metadata['PhasesPerComp']?[competitionId.toString()] as List<dynamic>?;
+
+      if (phasesForComp == null || phasesForComp.isEmpty) {
+         return [];
+      }
+      
+      final phaseId = phasesForComp.first['Id'];
+
+      final payload = {"GradeId": gradeId, "PhaseId": phaseId};
+
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/standings/Phase'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+
+      if (response.statusCode == 200) {
+        final List<dynamic> decodedData = json.decode(response.body);
+        return decodedData.map((tableData) => StandingsTable.fromCollegeSportJson(tableData)).toList();
+      }
+    } catch (e) {
+      print("CollegeSport Standings Error: $e");
+    }
+    return [];
+  }
+
+  // --- PRIVATE METHODS (RUGBY UNION) ---
+
+  Future<Map<String, dynamic>> _getRugbyUnionData() async {
+    if (_cachedRugbyUnionData != null) return _cachedRugbyUnionData!;
+    try {
+      final response = await http.get(Uri.parse(_rugbyUnionDataUrl));
+      if (response.statusCode == 200) {
+        _cachedRugbyUnionData = json.decode(response.body);
+        return _cachedRugbyUnionData!;
+      }
+    } catch (e) {
+      print("Rugby Union Data Error: $e");
+    }
+    return {'pageProps': {'competitions': [], 'clubs': []}};
+  }
+
+  Future<List<Fixture>> _getRugbyUnionFixtures({DateTimeRange? dateRange}) async {
+    final rugbyData = await _getRugbyUnionData();
+    final clubs = rugbyData['pageProps']?['clubs'] as List<dynamic>? ?? [];
+    final sacredHeartClub = clubs.firstWhere((c) => c['name'] == 'Sacred Heart College', orElse: () => null);
+
+    if (sacredHeartClub == null) return [];
+
+    final entityId = int.tryParse(sacredHeartClub['id'] ?? '');
+    if (entityId == null) return [];
+
+    final fixturesPayload = {
+      "operationName": "EntityFixturesAndResults",
+      "variables": {"season":"","comps":[],"teams":[],"type":"fixtures","skip":0,"limit":100,"entityId":entityId,"entityType":"club"},
+      "query": "query EntityFixturesAndResults(\$entityId: Int, \$entityType: String, \$season: String, \$comps: [CompInput], \$teams: [String], \$type: String, \$skip: Int, \$limit: Int) {\n  getEntityFixturesAndResults(\n    season: \$season\n    comps: \$comps\n    teams: \$teams\n    entityId: \$entityId\n    entityType: \$entityType\n    type: \$type\n    limit: \$limit\n    skip: \$skip\n  ) {\n    ...Fixtures_fixture\n    __typename\n  }\n}\n\nfragment Fixtures_fixture on FixtureItem {\n  id\n  compId\n  compName\n  dateTime\n  group\n  isLive\n  isBye\n  round\n  roundType\n  roundLabel\n  season\n  status\n  venue\n  sourceType\n  matchLabel\n  homeTeam {\n    ...Fixtures_team\n    __typename\n  }\n  awayTeam {\n    ...Fixtures_team\n    __typename\n  }\n  fixtureMeta {\n    ...Fixtures_meta\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_team on Team {\n  id\n  name\n  teamId\n  score\n  crest\n  __typename\n}\n\nfragment Fixtures_meta on Fixture {\n  id\n  ticketURL\n  ticketsAvailableDate\n  isSoldOut\n  radioURL\n  radioStart\n  radioEnd\n  streamURL\n  streamStart\n  streamEnd\n  broadcastPartners {\n    ...Fixtures_broadcastPartners\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_broadcastPartners on BroadcastPartner {\n  id\n  name\n  link\n  photoId\n  __typename\n}"
+    };
+    final resultsPayload = {
+      "operationName": "EntityFixturesAndResults",
+      "variables": {"season":"","comps":[],"teams":[],"type":"results","skip":0,"limit":100,"entityId":entityId,"entityType":"club"},
+      "query": "query EntityFixturesAndResults(\$entityId: Int, \$entityType: String, \$season: String, \$comps: [CompInput], \$teams: [String], \$type: String, \$skip: Int, \$limit: Int) {\n  getEntityFixturesAndResults(\n    season: \$season\n    comps: \$comps\n    teams: \$teams\n    entityId: \$entityId\n    entityType: \$entityType\n    type: \$type\n    limit: \$limit\n    skip: \$skip\n  ) {\n    ...Fixtures_fixture\n    __typename\n  }\n}\n\nfragment Fixtures_fixture on FixtureItem {\n  id\n  compId\n  compName\n  dateTime\n  group\n  isLive\n  isBye\n  round\n  roundType\n  roundLabel\n  season\n  status\n  venue\n  sourceType\n  matchLabel\n  homeTeam {\n    ...Fixtures_team\n    __typename\n  }\n  awayTeam {\n    ...Fixtures_team\n    __typename\n  }\n  fixtureMeta {\n    ...Fixtures_meta\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_team on Team {\n  id\n  name\n  teamId\n  score\n  crest\n  __typename\n}\n\nfragment Fixtures_meta on Fixture {\n  id\n  ticketURL\n  ticketsAvailableDate\n  isSoldOut\n  radioURL\n  radioStart\n  radioEnd\n  streamURL\n  streamStart\n  streamEnd\n  broadcastPartners {\n    ...Fixtures_broadcastPartners\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_broadcastPartners on BroadcastPartner {\n  id\n  name\n  link\n  photoId\n  __typename\n}"
+    };
+
+    try {
+      final responses = await Future.wait([
+        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(fixturesPayload)),
+        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(resultsPayload)),
+      ]);
+
+      List<Fixture> allRugbyFixtures = [];
+      const String sacredHeartName = "Sacred Heart College";
+
+      for (final response in responses) {
+        if (response.statusCode == 200) {
+          final decodedData = json.decode(response.body);
+          final List<dynamic> fixtureData = decodedData['data']?['getEntityFixturesAndResults'] ?? [];
+          
+          final sacredHeartFixtures = fixtureData
+            .where((data) {
+                final homeTeamName = data['homeTeam']?['name'] as String? ?? '';
+                final awayTeamName = data['awayTeam']?['name'] as String? ?? '';
+                return homeTeamName.contains(sacredHeartName) || awayTeamName.contains(sacredHeartName);
+            })
+            .map((data) => Fixture.fromRugbyUnionJson(data));
+
+          allRugbyFixtures.addAll(sacredHeartFixtures);
+        }
+      }
+
+      if (dateRange != null) {
+        return allRugbyFixtures.where((f) {
+          try {
+            final fixtureDate = DateTime.parse(f.dateTime);
+            return fixtureDate.isAfter(dateRange.start.subtract(const Duration(days: 1))) && fixtureDate.isBefore(dateRange.end.add(const Duration(days: 1)));
+          } catch(e) {
+            return false;
+          }
+        }).toList();
+      }
+      
+      return allRugbyFixtures;
+
+    } catch (e) {
+      print("Rugby Union Fixtures Error: $e");
+    }
+    return [];
+  }
+
+  Future<List<StandingsTable>> _getRugbyUnionStandings(String competitionId) async {
+    final payload = {
+      "operationName": "CompLadderQuery",
+      "variables": {"comp": {"id": competitionId, "sourceType": "2"}},
+      "query": "query CompLadderQuery(\$comp: CompInput) {\n  compLadder(comp: \$comp) {\n    ...LadderCard_ladder\n    __typename\n  }\n}\n\nfragment LadderCard_ladder on Ladder {\n  id\n  hasPools\n  ladderPools {\n    id\n    poolName\n    teams {\n      ...LadderCard_ladderTeam\n      __typename\n    }\n    __typename\n  }\n  sortingOptions\n  overallSort\n  __typename\n}\n\nfragment LadderCard_ladderTeam on LadderTeam {\n  active\n  bonusPoints3T\n  bonusPoints4T\n  bonusPoints7P\n  byes\n  crest\n  id\n  matchWinRatio\n  matchesDrawn\n  matchesLost\n  matchesPlayed\n  matchesWon\n  name\n  numberForfeitsLoss\n  numberForfeitsWin\n  numberOfForfeits\n  pointsADJ\n  pointsAgainst\n  pointsAgainstADJ\n  pointsDifference\n  pointsFor\n  pointsForADJ\n  pointsRatio\n  position\n  scoreRatio\n  totalBonusPoints\n  totalMatchPoints\n  totalTries\n  tryDifference\n  __typename\n}"
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(_rugbyUnionApiUrl),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+
+      if (response.statusCode == 200) {
+        final decodedData = json.decode(response.body);
+        final ladderData = decodedData['data']?['compLadder'];
+        if (ladderData != null) {
+          return [StandingsTable.fromRugbyUnionJson(ladderData)];
+        }
+      }
+    } catch (e) {
+      print("Rugby Union Standings Error: $e");
+    }
+    return [];
   }
 }

--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -1,39 +1,19 @@
 // lib/api_service.dart
 
-import 'package:http/http.dart' as http;
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'models.dart'; // Only imports models, does not define them.
+import 'models.dart';
+import 'services/collegesport_api_service.dart';
+import 'services/rugbyunion_api_service.dart';
 
 class ApiService {
-  // --- Headers ---
-  static final Map<String, String> _headers = {
-    'Content-Type': 'application/json',
-    'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
-  };
+  final CollegeSportApiService _collegeSportApi = CollegeSportApiService();
+  final RugbyUnionApiService _rugbyUnionApi = RugbyUnionApiService();
 
-  // --- PROXY AND API URLS ---
-  static const String _proxyBaseUrl = "http://localhost:9999";
-
-  // --- CollegeSport API (via proxy) ---
-  static const String _collegeSportBaseUrl = "$_proxyBaseUrl/collegesport/api/v2/competition/widget";
-  Map<String, dynamic>? _cachedCollegeSportMetadata;
-  List<Fixture>? _cachedCollegeSportFixtures;
-
-  // --- Rugby Union API (partially via proxy) ---
-  static const String _rugbyUnionApiUrl = "https://rugby-au-cms.graphcdn.app/"; // Direct, as it has CORS enabled
-  Map<String, dynamic>? _cachedRugbyUnionData;
-  String? _cachedRugbyBuildId;
-
-  // --- Shared Data ---
   static const Map<String, String> _sportIcons = {
     'Football': '⚽', 'Basketball': '🏀', 'Tennis': '🎾', 'Cricket': '🏏',
     'Hockey': '🏒', 'Rugby Union': '🏉', 'Volleyball': '🏐', 'Netball': '🥅',
     'Default': '🏅',
   };
-
-  // --- PUBLIC METHODS (ORCHESTRATORS) ---
 
   Future<List<Sport>> getSportsForSacredHeart() async {
     final List<Fixture> allFixtures = await getFixtures();
@@ -42,7 +22,8 @@ class ApiService {
     final List<Sport> sports = sportNames.map((name) {
       final icon = _sportIcons[name] ?? _sportIcons['Default']!;
       final id = name.hashCode; 
-      return Sport(id: id, name: name, icon: icon, source: name == 'Rugby Union' ? DataSource.rugbyUnion : DataSource.collegeSport);
+      final source = name == 'Rugby Union' ? DataSource.rugbyUnion : DataSource.collegeSport;
+      return Sport(id: id, name: name, icon: icon, source: source);
     }).toList();
 
     sports.sort((a, b) => a.name.compareTo(b.name));
@@ -51,8 +32,8 @@ class ApiService {
 
   Future<List<Fixture>> getFixtures({DateTimeRange? dateRange}) async {
     final results = await Future.wait([
-      _getCollegeSportFixtures(dateRange: dateRange),
-      _getRugbyUnionFixtures(dateRange: dateRange),
+      _collegeSportApi.getFixtures(dateRange: dateRange),
+      _rugbyUnionApi.getFixtures(dateRange: dateRange),
     ]);
 
     final allFixtures = results.expand((fixtures) => fixtures).toList();
@@ -89,243 +70,9 @@ class ApiService {
 
   Future<List<StandingsTable>> getStandings(String competitionId, int gradeId, DataSource source) async {
     if (source == DataSource.collegeSport) {
-      return _getCollegeSportStandings(int.parse(competitionId), gradeId);
+      return _collegeSportApi.getStandings(int.parse(competitionId), gradeId);
     } else {
-      return _getRugbyUnionStandings(competitionId);
+      return _rugbyUnionApi.getStandings(competitionId);
     }
-  }
-
-  // --- PRIVATE METHODS (COLLEGESPORT) ---
-
-  Future<Map<String, dynamic>> _getCollegeSportMetadata() async {
-    if (_cachedCollegeSportMetadata != null) return _cachedCollegeSportMetadata!;
-
-    final payload = [ "10362", "10180", "10181", "10182", "10183", "10184", "10113", "10114", "10115", "10116", "10286", "10288", "10394", "10395", "10396", "10401", "10402", "10403", "10045", "10033", "10034", "10041", "11769", "11109", "11110", "11226", "11227", "10197", "10333", "10334", "10335", "10336", "10337", "10340", "10202", "10203", "10204", "10205", "10206", "10821", "9982", "9983", "9995", "9996", "9974", "9975", "9976", "9977", "9978", "9979", "9980", "9981", "10017", "10046", "10047", "10005", "10006", "10124", "10125", "10126", "10292", "10296", "11261", "10121", "10025", "10026", "10035", "10147", "10148", "10341", "10342", "10343", "10137", "10138", "10185", "10186", "10140", "10141", "10190", "10191", "10207", "10208", "10209", "10200", "10257", "10192", "10193", "10194", "10195", "10196", "10305" ];
-    
-    try {
-      final response = await http.post(
-        Uri.parse('$_collegeSportBaseUrl/metadata/'),
-        headers: _headers,
-        body: json.encode(payload),
-      );
-      if (response.statusCode == 200) {
-        _cachedCollegeSportMetadata = json.decode(response.body);
-        return _cachedCollegeSportMetadata!;
-      }
-    } catch (e) {
-      print("CollegeSport Metadata Error: $e");
-    }
-    return {'Sports': [], 'Competitions': [], 'GradesPerComp': {}, 'OrgsPerComp': {}};
-  }
-
-  Future<List<Fixture>> _getCollegeSportFixtures({DateTimeRange? dateRange}) async {
-    if (_cachedCollegeSportFixtures != null && dateRange == null) {
-      return _cachedCollegeSportFixtures!;
-    }
-
-    final metadata = await _getCollegeSportMetadata();
-    if (metadata['Competitions'].isEmpty) return [];
-
-    final allCompIds = (metadata['Competitions'] as List).map<int>((c) => c['Id']).toList();
-    final allGradeIds = (metadata['GradesPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((g) => g['Id'] as int).toSet().toList();
-    final allOrgIds = (metadata['OrgsPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((o) => o['Id'] as int).toSet().toList();
-
-    final fromDate = (dateRange?.start ?? DateTime.now().subtract(const Duration(days: 30))).toIso8601String().substring(0, 10);
-    final toDate = (dateRange?.end ?? DateTime.now().add(const Duration(days: 30))).toIso8601String().substring(0, 10);
-
-    final payload = {
-      "CompIds": allCompIds, "OrgIds": allOrgIds, "GradeIds": allGradeIds,
-      "From": "${fromDate}T00:00:00", "To": "${toDate}T23:59:00"
-    };
-
-    try {
-      final response = await http.post(
-        Uri.parse('$_collegeSportBaseUrl/fixture/Dates'),
-        headers: _headers,
-        body: json.encode(payload),
-      );
-
-      if (response.statusCode == 200) {
-        final Map<String, dynamic> decodedData = json.decode(response.body);
-        final List<dynamic> fixtureData = decodedData['Fixtures'] as List<dynamic>? ?? [];
-        const String schoolToFilter = "Sacred Heart College (Auckland)";
-
-        final fixtures = fixtureData
-            .where((data) =>
-                data['HomeOrgName'] == schoolToFilter ||
-                data['AwayOrgName'] == schoolToFilter)
-            .map((data) => Fixture.fromCollegeSportJson(data, metadata))
-            .toList();
-
-        if (dateRange == null) _cachedCollegeSportFixtures = fixtures;
-        return fixtures;
-      }
-    } catch (e) {
-      print("CollegeSport Fixtures Error: $e");
-    }
-    return [];
-  }
-
-  Future<List<StandingsTable>> _getCollegeSportStandings(int competitionId, int gradeId) async {
-    try {
-      final metadata = await _getCollegeSportMetadata();
-      final phasesForComp = metadata['PhasesPerComp']?[competitionId.toString()] as List<dynamic>?;
-
-      if (phasesForComp == null || phasesForComp.isEmpty) {
-         return [];
-      }
-      
-      final phaseId = phasesForComp.first['Id'];
-
-      final payload = {"GradeId": gradeId, "PhaseId": phaseId};
-
-      final response = await http.post(
-        Uri.parse('$_collegeSportBaseUrl/standings/Phase'),
-        headers: _headers,
-        body: json.encode(payload),
-      );
-
-      if (response.statusCode == 200) {
-        final List<dynamic> decodedData = json.decode(response.body);
-        return decodedData.map((tableData) => StandingsTable.fromCollegeSportJson(tableData)).toList();
-      }
-    } catch (e) {
-      print("CollegeSport Standings Error: $e");
-    }
-    return [];
-  }
-
-  // --- PRIVATE METHODS (RUGBY UNION) ---
-
-  Future<String> _getRugbyUnionBuildId() async {
-    if (_cachedRugbyBuildId != null) return _cachedRugbyBuildId!;
-
-    final url = Uri.parse("$_proxyBaseUrl/aucklandrugby/fixtures-and-results");
-    try {
-      final response = await http.get(url);
-      if (response.statusCode == 200) {
-        final body = response.body;
-        final pattern = RegExp(r'"buildId":"([^"]+)"');
-        final match = pattern.firstMatch(body);
-        if (match != null && match.group(1) != null) {
-          _cachedRugbyBuildId = match.group(1);
-          print('Successfully fetched new Rugby Union Build ID: $_cachedRugbyBuildId');
-          return _cachedRugbyBuildId!;
-        }
-      }
-      throw Exception('Failed to find Rugby Union buildId in HTML response.');
-    } catch (e) {
-      print('Error fetching Rugby Union build ID: $e');
-      return 'EYwFsoHsI7WQjAopi5hIv';
-    }
-  }
-
-  Future<Map<String, dynamic>> _getRugbyUnionData() async {
-    if (_cachedRugbyUnionData != null) return _cachedRugbyUnionData!;
-    try {
-      final buildId = await _getRugbyUnionBuildId();
-      final rugbyUnionDataUrl = "$_proxyBaseUrl/aucklandrugby/_next/data/$buildId/fixtures-results.json";
-      final response = await http.get(Uri.parse(rugbyUnionDataUrl));
-      if (response.statusCode == 200) {
-        _cachedRugbyUnionData = json.decode(response.body);
-        return _cachedRugbyUnionData!;
-      }
-    } catch (e) {
-      print("Rugby Union Data Error: $e");
-    }
-    return {'pageProps': {'competitions': [], 'clubs': []}};
-  }
-
-  Future<List<Fixture>> _getRugbyUnionFixtures({DateTimeRange? dateRange}) async {
-    final rugbyData = await _getRugbyUnionData();
-    final clubs = rugbyData['pageProps']?['clubs'] as List<dynamic>? ?? [];
-    final sacredHeartClub = clubs.firstWhere((c) => c['name'] == 'Sacred Heart College', orElse: () => null);
-
-    if (sacredHeartClub == null) return [];
-
-    final entityId = int.tryParse(sacredHeartClub['id'] ?? '');
-    if (entityId == null) return [];
-
-    final fixturesPayload = {
-      "operationName": "EntityFixturesAndResults",
-      "variables": {"season":"","comps":[],"teams":[],"type":"fixtures","skip":0,"limit":100,"entityId":entityId,"entityType":"club"},
-      "query": "query EntityFixturesAndResults(\$entityId: Int, \$entityType: String, \$season: String, \$comps: [CompInput], \$teams: [String], \$type: String, \$skip: Int, \$limit: Int) {\n  getEntityFixturesAndResults(\n    season: \$season\n    comps: \$comps\n    teams: \$teams\n    entityId: \$entityId\n    entityType: \$entityType\n    type: \$type\n    limit: \$limit\n    skip: \$skip\n  ) {\n    ...Fixtures_fixture\n    __typename\n  }\n}\n\nfragment Fixtures_fixture on FixtureItem {\n  id\n  compId\n  compName\n  dateTime\n  group\n  isLive\n  isBye\n  round\n  roundType\n  roundLabel\n  season\n  status\n  venue\n  sourceType\n  matchLabel\n  homeTeam {\n    ...Fixtures_team\n    __typename\n  }\n  awayTeam {\n    ...Fixtures_team\n    __typename\n  }\n  fixtureMeta {\n    ...Fixtures_meta\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_team on Team {\n  id\n  name\n  teamId\n  score\n  crest\n  __typename\n}\n\nfragment Fixtures_meta on Fixture {\n  id\n  ticketURL\n  ticketsAvailableDate\n  isSoldOut\n  radioURL\n  radioStart\n  radioEnd\n  streamURL\n  streamStart\n  streamEnd\n  broadcastPartners {\n    ...Fixtures_broadcastPartners\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_broadcastPartners on BroadcastPartner {\n  id\n  name\n  link\n  photoId\n  __typename\n}"
-    };
-    final resultsPayload = {
-      "operationName": "EntityFixturesAndResults",
-      "variables": {"season":"","comps":[],"teams":[],"type":"results","skip":0,"limit":100,"entityId":entityId,"entityType":"club"},
-      "query": "query EntityFixturesAndResults(\$entityId: Int, \$entityType: String, \$season: String, \$comps: [CompInput], \$teams: [String], \$type: String, \$skip: Int, \$limit: Int) {\n  getEntityFixturesAndResults(\n    season: \$season\n    comps: \$comps\n    teams: \$teams\n    entityId: \$entityId\n    entityType: \$entityType\n    type: \$type\n    limit: \$limit\n    skip: \$skip\n  ) {\n    ...Fixtures_fixture\n    __typename\n  }\n}\n\nfragment Fixtures_fixture on FixtureItem {\n  id\n  compId\n  compName\n  dateTime\n  group\n  isLive\n  isBye\n  round\n  roundType\n  roundLabel\n  season\n  status\n  venue\n  sourceType\n  matchLabel\n  homeTeam {\n    ...Fixtures_team\n    __typename\n  }\n  awayTeam {\n    ...Fixtures_team\n    __typename\n  }\n  fixtureMeta {\n    ...Fixtures_meta\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_team on Team {\n  id\n  name\n  teamId\n  score\n  crest\n  __typename\n}\n\nfragment Fixtures_meta on Fixture {\n  id\n  ticketURL\n  ticketsAvailableDate\n  isSoldOut\n  radioURL\n  radioStart\n  radioEnd\n  streamURL\n  streamStart\n  streamEnd\n  broadcastPartners {\n    ...Fixtures_broadcastPartners\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_broadcastPartners on BroadcastPartner {\n  id\n  name\n  link\n  photoId\n  __typename\n}"
-    };
-
-    try {
-      final responses = await Future.wait([
-        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(fixturesPayload)),
-        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(resultsPayload)),
-      ]);
-
-      List<Fixture> allRugbyFixtures = [];
-      const String sacredHeartName = "Sacred Heart College";
-
-      for (final response in responses) {
-        if (response.statusCode == 200) {
-          final decodedData = json.decode(response.body);
-          final List<dynamic> fixtureData = decodedData['data']?['getEntityFixturesAndResults'] ?? [];
-          
-          final sacredHeartFixtures = fixtureData
-            .where((data) {
-                final homeTeamName = data['homeTeam']?['name'] as String? ?? '';
-                final awayTeamName = data['awayTeam']?['name'] as String? ?? '';
-                return homeTeamName.contains(sacredHeartName) || awayTeamName.contains(sacredHeartName);
-            })
-            .map((data) => Fixture.fromRugbyUnionJson(data));
-
-          allRugbyFixtures.addAll(sacredHeartFixtures);
-        }
-      }
-
-      if (dateRange != null) {
-        return allRugbyFixtures.where((f) {
-          try {
-            final fixtureDate = DateTime.parse(f.dateTime);
-            return fixtureDate.isAfter(dateRange.start.subtract(const Duration(days: 1))) && fixtureDate.isBefore(dateRange.end.add(const Duration(days: 1)));
-          } catch(e) {
-            return false;
-          }
-        }).toList();
-      }
-      
-      return allRugbyFixtures;
-
-    } catch (e) {
-      print("Rugby Union Fixtures Error: $e");
-    }
-    return [];
-  }
-
-  Future<List<StandingsTable>> _getRugbyUnionStandings(String competitionId) async {
-    final payload = {
-      "operationName": "CompLadderQuery",
-      "variables": {"comp": {"id": competitionId, "sourceType": "2"}},
-      "query": "query CompLadderQuery(\$comp: CompInput) {\n  compLadder(comp: \$comp) {\n    ...LadderCard_ladder\n    __typename\n  }\n}\n\nfragment LadderCard_ladder on Ladder {\n  id\n  hasPools\n  ladderPools {\n    id\n    poolName\n    teams {\n      ...LadderCard_ladderTeam\n      __typename\n    }\n    __typename\n  }\n  sortingOptions\n  overallSort\n  __typename\n}\n\nfragment LadderCard_ladderTeam on LadderTeam {\n  active\n  bonusPoints3T\n  bonusPoints4T\n  bonusPoints7P\n  byes\n  crest\n  id\n  matchWinRatio\n  matchesDrawn\n  matchesLost\n  matchesPlayed\n  matchesWon\n  name\n  numberForfeitsLoss\n  numberForfeitsWin\n  numberOfForfeits\n  pointsADJ\n  pointsAgainst\n  pointsAgainstADJ\n  pointsDifference\n  pointsFor\n  pointsForADJ\n  pointsRatio\n  position\n  scoreRatio\n  totalBonusPoints\n  totalMatchPoints\n  totalTries\n  tryDifference\n  __typename\n}"
-    };
-
-    try {
-      final response = await http.post(
-        Uri.parse(_rugbyUnionApiUrl),
-        headers: _headers,
-        body: json.encode(payload),
-      );
-
-      if (response.statusCode == 200) {
-        final decodedData = json.decode(response.body);
-        final ladderData = decodedData['data']?['compLadder'];
-        if (ladderData != null) {
-          return [StandingsTable.fromRugbyUnionJson(ladderData)];
-        }
-      }
-    } catch (e) {
-      print("Rugby Union Standings Error: $e");
-    }
-    return [];
   }
 }

--- a/lib/fixture_detail_screen.dart
+++ b/lib/fixture_detail_screen.dart
@@ -5,12 +5,71 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
 import 'models.dart';
 
-class FixtureDetailScreen extends StatelessWidget {
+class FixtureDetailScreen extends StatefulWidget {
   final Fixture fixture;
 
   const FixtureDetailScreen({super.key, required this.fixture});
+
+  @override
+  State<FixtureDetailScreen> createState() => _FixtureDetailScreenState();
+}
+
+class _FixtureDetailScreenState extends State<FixtureDetailScreen> {
+  LatLng? _coordinates;
+  bool _isLoadingMap = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.fixture.lat != null && widget.fixture.lng != null) {
+      _coordinates = LatLng(widget.fixture.lat!, widget.fixture.lng!);
+    } 
+    else if (widget.fixture.source == DataSource.rugbyUnion && widget.fixture.venue.isNotEmpty) {
+      _fetchCoordinatesForVenue();
+    }
+  }
+
+  String get _cleanedVenueName {
+    return widget.fixture.venue.replaceAll(RegExp(r'\s+\d+\s*\w?$'), '').trim();
+  }
+
+  Future<void> _fetchCoordinatesForVenue() async {
+    setState(() {
+      _isLoadingMap = true;
+    });
+
+    final query = Uri.encodeComponent(_cleanedVenueName);
+    // Use API parameters to restrict the search to NZ and bias it towards the Auckland region for better accuracy.
+    const aucklandViewbox = '174.45,-37.2,175.15,-36.5'; // A rough bounding box for the Auckland area
+    final url = Uri.parse('https://nominatim.openstreetmap.org/search?q=$query&format=json&limit=1&countrycodes=nz&viewbox=$aucklandViewbox&bounded=1');
+
+    try {
+      final response = await http.get(url, headers: {'User-Agent': 'Flutter Sports Fixtures App'});
+      if (response.statusCode == 200) {
+        final results = json.decode(response.body) as List;
+        if (results.isNotEmpty) {
+          final firstResult = results.first;
+          final lat = double.tryParse(firstResult['lat']);
+          final lon = double.tryParse(firstResult['lon']);
+          if (lat != null && lon != null) {
+            setState(() {
+              _coordinates = LatLng(lat, lon);
+            });
+          }
+        }
+      }
+    } catch (e) {
+      print('Failed to fetch coordinates: $e');
+    } finally {
+      setState(() {
+        _isLoadingMap = false;
+      });
+    }
+  }
 
   String _formatDateTime(String dateTimeString) {
     if (dateTimeString.isEmpty) return 'Date TBC';
@@ -22,8 +81,14 @@ class FixtureDetailScreen extends StatelessWidget {
     }
   }
 
-  Future<void> _launchMapsUrl(double lat, double lng) async {
-    final Uri url = Uri.parse('https://www.google.com/maps/search/?api=1&query=$lat,$lng');
+  Future<void> _launchMapsUrl() async {
+    Uri url;
+    if (_coordinates != null) {
+      url = Uri.parse('https://www.google.com/maps/search/?api=1&query=${_coordinates!.latitude},${_coordinates!.longitude}');
+    } else {
+      url = Uri.parse('https://www.google.com/maps/search/?api=1&query=${Uri.encodeComponent(_cleanedVenueName)}, Auckland');
+    }
+    
     if (!await launchUrl(url)) {
       throw Exception('Could not launch $url');
     }
@@ -33,7 +98,7 @@ class FixtureDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(fixture.sport),
+        title: Text(widget.fixture.sport),
       ),
       body: LayoutBuilder(
         builder: (context, constraints) {
@@ -48,7 +113,6 @@ class FixtureDetailScreen extends StatelessWidget {
   }
 
   Widget _buildNarrowLayout(BuildContext context) {
-    final hasLocation = fixture.lat != null && fixture.lng != null;
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -56,13 +120,13 @@ class FixtureDetailScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              fixture.competition,
+              widget.fixture.competition,
               style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(height: 24),
-            _TeamVsWidget(fixture: fixture),
+            _TeamVsWidget(fixture: widget.fixture),
             const SizedBox(height: 16),
-            if (fixture.premier)
+            if (widget.fixture.premier)
               Chip(
                 label: const Text('Premier'),
                 backgroundColor:
@@ -76,15 +140,15 @@ class FixtureDetailScreen extends StatelessWidget {
             const SizedBox(height: 8),
             SizedBox(
               height: 300,
-              child: _buildMap(hasLocation),
+              child: _buildMap(),
             ),
             const SizedBox(height: 16),
-            if (hasLocation)
+            if (widget.fixture.venue.isNotEmpty)
               Center(
                 child: ElevatedButton.icon(
                   icon: const Icon(Icons.directions),
                   label: const Text('Get Directions'),
-                  onPressed: () => _launchMapsUrl(fixture.lat!, fixture.lng!),
+                  onPressed: _launchMapsUrl,
                   style: ElevatedButton.styleFrom(
                     foregroundColor: Theme.of(context).colorScheme.onPrimary,
                     backgroundColor: Theme.of(context).colorScheme.primary,
@@ -98,7 +162,6 @@ class FixtureDetailScreen extends StatelessWidget {
   }
 
   Widget _buildWideLayout(BuildContext context) {
-    final hasLocation = fixture.lat != null && fixture.lng != null;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32.0, vertical: 24.0),
       child: Row(
@@ -111,7 +174,7 @@ class FixtureDetailScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    fixture.competition,
+                    widget.fixture.competition,
                     style: Theme.of(context)
                         .textTheme
                         .headlineMedium
@@ -119,12 +182,12 @@ class FixtureDetailScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 32),
                   _TeamVsWidget(
-                    fixture: fixture,
+                    fixture: widget.fixture,
                     iconSize: 40,
                     textStyle: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: 16),
-                  if (fixture.premier)
+                  if (widget.fixture.premier)
                     Chip(
                       label: const Text('Premier'),
                       visualDensity: VisualDensity.compact,
@@ -150,15 +213,15 @@ class FixtureDetailScreen extends StatelessWidget {
                 Text("Location Map", style: Theme.of(context).textTheme.titleLarge),
                 const SizedBox(height: 16),
                 Expanded(
-                  child: _buildMap(hasLocation),
+                  child: _buildMap(),
                 ),
                 const SizedBox(height: 16),
-                if (hasLocation)
+                if (widget.fixture.venue.isNotEmpty)
                   Center(
                     child: ElevatedButton.icon(
                       icon: const Icon(Icons.directions),
                       label: const Text('Get Directions'),
-                      onPressed: () => _launchMapsUrl(fixture.lat!, fixture.lng!),
+                      onPressed: _launchMapsUrl,
                       style: ElevatedButton.styleFrom(
                         foregroundColor: Theme.of(context).colorScheme.onPrimary,
                         backgroundColor: Theme.of(context).colorScheme.primary,
@@ -191,7 +254,7 @@ class FixtureDetailScreen extends StatelessWidget {
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
-                  _formatDateTime(fixture.dateTime),
+                  _formatDateTime(widget.fixture.dateTime),
                   style: textStyle,
                 ),
               ),
@@ -202,7 +265,7 @@ class FixtureDetailScreen extends StatelessWidget {
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
-                  fixture.venue,
+                  widget.fixture.venue,
                   style: textStyle,
                 ),
               ),
@@ -213,37 +276,39 @@ class FixtureDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildMap(bool hasLocation) {
+  Widget _buildMap() {
     return ClipRRect(
       borderRadius: BorderRadius.circular(12),
-      child: hasLocation
-          ? FlutterMap(
-              options: MapOptions(
-                initialCenter: LatLng(fixture.lat!, fixture.lng!),
-                initialZoom: 15.0,
-              ),
-              children: [
-                TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  userAgentPackageName: 'com.example.app',
-                ),
-                MarkerLayer(
-                  markers: [
-                    Marker(
-                      point: LatLng(fixture.lat!, fixture.lng!),
-                      width: 80,
-                      height: 80,
-                      child: Icon(Icons.location_pin,
-                          size: 40, color: Colors.red.shade700),
+      child: Container(
+        color: Colors.grey.withOpacity(0.2),
+        child: _isLoadingMap
+            ? const Center(child: CircularProgressIndicator())
+            : _coordinates != null
+                ? FlutterMap(
+                    options: MapOptions(
+                      initialCenter: _coordinates!,
+                      initialZoom: 15.0,
                     ),
-                  ],
-                ),
-              ],
-            )
-          : Container(
-              color: Colors.grey.withOpacity(0.2),
-              child: const Center(child: Text('Map data not available')),
-            ),
+                    children: [
+                      TileLayer(
+                        urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        userAgentPackageName: 'com.example.app',
+                      ),
+                      MarkerLayer(
+                        markers: [
+                          Marker(
+                            point: _coordinates!,
+                            width: 80,
+                            height: 80,
+                            child: Icon(Icons.location_pin,
+                                size: 40, color: Colors.red.shade700),
+                          ),
+                        ],
+                      ),
+                    ],
+                  )
+                : const Center(child: Text('Map data not available')),
+      ),
     );
   }
 }
@@ -259,8 +324,6 @@ class _TeamVsWidget extends StatelessWidget {
     this.textStyle,
   });
 
-  // --- MODIFIED ---
-  // This widget now displays the score if the game is finished.
   Widget _buildTeamRow(BuildContext context, String school, String team, String? logoUrl, String? score) {
     final effectiveTextStyle = textStyle ?? Theme.of(context).textTheme.titleMedium;
     final bool isFinished = (fixture.homeScore != null && fixture.homeScore!.isNotEmpty) || 
@@ -286,8 +349,6 @@ class _TeamVsWidget extends StatelessWidget {
             style: effectiveTextStyle,
           ),
         ),
-        // --- NEW ---
-        // Display the score on the right if the game is finished.
         if (isFinished)
           Padding(
             padding: const EdgeInsets.only(left: 16.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'upcoming_fixture_widget.dart';
 import 'api_service.dart';
 import 'models.dart';
-import 'contact_us_page.dart'; // Import the new contact page
+import 'contact_us_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -256,8 +256,6 @@ class _SportsListColumnState extends State<SportsListColumn> {
       _selectedTeam = teamName;
       _teamFixturesFuture = _apiService.getFixturesForTeam(teamName);
       
-      // --- MODIFIED ---
-      // This now correctly passes the required IDs and the data source to the getStandings method.
       _standingsFuture = _teamFixturesFuture!.then((fixtures) {
         if (fixtures.isNotEmpty) {
           final firstFixture = fixtures.first;
@@ -265,7 +263,6 @@ class _SportsListColumnState extends State<SportsListColumn> {
           final gradeId = firstFixture.gradeId;
           final source = firstFixture.source;
           
-          // GradeId can be null for Rugby Union, so we provide a default.
           return _apiService.getStandings(competitionId, gradeId ?? 0, source);
         } else {
           return <StandingsTable>[];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,8 +93,6 @@ class _LandingPageState extends State<LandingPage> {
       appBar: AppBar(
         title: Text(_currentViewTitle),
         actions: [
-          // --- MODIFIED ---
-          // The Contact Us button now navigates to the new page.
           TextButton(
             onPressed: () {
               Navigator.push(
@@ -258,12 +256,17 @@ class _SportsListColumnState extends State<SportsListColumn> {
       _selectedTeam = teamName;
       _teamFixturesFuture = _apiService.getFixturesForTeam(teamName);
       
+      // --- MODIFIED ---
+      // This now correctly passes the required IDs and the data source to the getStandings method.
       _standingsFuture = _teamFixturesFuture!.then((fixtures) {
         if (fixtures.isNotEmpty) {
           final firstFixture = fixtures.first;
           final competitionId = firstFixture.competitionId;
           final gradeId = firstFixture.gradeId;
-          return _apiService.getStandings(competitionId, gradeId);
+          final source = firstFixture.source;
+          
+          // GradeId can be null for Rugby Union, so we provide a default.
+          return _apiService.getStandings(competitionId, gradeId ?? 0, source);
         } else {
           return <StandingsTable>[];
         }

--- a/lib/services/collegesport_api_service.dart
+++ b/lib/services/collegesport_api_service.dart
@@ -1,0 +1,120 @@
+// lib/services/collegesport_api_service.dart
+
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../models.dart';
+
+class CollegeSportApiService {
+  static final CollegeSportApiService _instance = CollegeSportApiService._internal();
+  factory CollegeSportApiService() => _instance;
+  CollegeSportApiService._internal();
+
+  static const String _proxyBaseUrl = "http://localhost:9999";
+  static const String _collegeSportBaseUrl = "$_proxyBaseUrl/collegesport/api/v2/competition/widget";
+  
+  static final Map<String, String> _headers = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  };
+
+  Map<String, dynamic>? _cachedMetadata;
+  List<Fixture>? _cachedFixtures;
+
+  Future<List<Fixture>> getFixtures({DateTimeRange? dateRange}) async {
+    if (_cachedFixtures != null && dateRange == null) {
+      return _cachedFixtures!;
+    }
+
+    final metadata = await _getMetadata();
+    if (metadata['Competitions'].isEmpty) return [];
+
+    final allCompIds = (metadata['Competitions'] as List).map<int>((c) => c['Id']).toList();
+    final allGradeIds = (metadata['GradesPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((g) => g['Id'] as int).toSet().toList();
+    final allOrgIds = (metadata['OrgsPerComp'].values as Iterable).expand<dynamic>((e) => e as List).map<int>((o) => o['Id'] as int).toSet().toList();
+
+    final fromDate = (dateRange?.start ?? DateTime.now().subtract(const Duration(days: 30))).toIso8601String().substring(0, 10);
+    final toDate = (dateRange?.end ?? DateTime.now().add(const Duration(days: 30))).toIso8601String().substring(0, 10);
+
+    final payload = {
+      "CompIds": allCompIds, "OrgIds": allOrgIds, "GradeIds": allGradeIds,
+      "From": "${fromDate}T00:00:00", "To": "${toDate}T23:59:00"
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/fixture/Dates'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> decodedData = json.decode(response.body);
+        final List<dynamic> fixtureData = decodedData['Fixtures'] as List<dynamic>? ?? [];
+        const String schoolToFilter = "Sacred Heart College (Auckland)";
+
+        final fixtures = fixtureData
+            .where((data) =>
+                data['HomeOrgName'] == schoolToFilter ||
+                data['AwayOrgName'] == schoolToFilter)
+            .map((data) => Fixture.fromCollegeSportJson(data, metadata))
+            .toList();
+
+        if (dateRange == null) _cachedFixtures = fixtures;
+        return fixtures;
+      }
+    } catch (e) {
+      print("CollegeSport Fixtures Error: $e");
+    }
+    return [];
+  }
+
+  Future<List<StandingsTable>> getStandings(int competitionId, int gradeId) async {
+    try {
+      final metadata = await _getMetadata();
+      final phasesForComp = metadata['PhasesPerComp']?[competitionId.toString()] as List<dynamic>?;
+
+      if (phasesForComp == null || phasesForComp.isEmpty) {
+         return [];
+      }
+      
+      final phaseId = phasesForComp.first['Id'];
+      final payload = {"GradeId": gradeId, "PhaseId": phaseId};
+
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/standings/Phase'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+
+      if (response.statusCode == 200) {
+        final List<dynamic> decodedData = json.decode(response.body);
+        return decodedData.map((tableData) => StandingsTable.fromCollegeSportJson(tableData)).toList();
+      }
+    } catch (e) {
+      print("CollegeSport Standings Error: $e");
+    }
+    return [];
+  }
+
+  Future<Map<String, dynamic>> _getMetadata() async {
+    if (_cachedMetadata != null) return _cachedMetadata!;
+
+    final payload = [ "10362", "10180", "10181", "10182", "10183", "10184", "10113", "10114", "10115", "10116", "10286", "10288", "10394", "10395", "10396", "10401", "10402", "10403", "10045", "10033", "10034", "10041", "11769", "11109", "11110", "11226", "11227", "10197", "10333", "10334", "10335", "10336", "10337", "10340", "10202", "10203", "10204", "10205", "10206", "10821", "9982", "9983", "9995", "9996", "9974", "9975", "9976", "9977", "9978", "9979", "9980", "9981", "10017", "10046", "10047", "10005", "10006", "10124", "10125", "10126", "10292", "10296", "11261", "10121", "10025", "10026", "10035", "10147", "10148", "10341", "10342", "10343", "10137", "10138", "10185", "10186", "10140", "10141", "10190", "10191", "10207", "10208", "10209", "10200", "10257", "10192", "10193", "10194", "10195", "10196", "10305" ];
+    
+    try {
+      final response = await http.post(
+        Uri.parse('$_collegeSportBaseUrl/metadata/'),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+      if (response.statusCode == 200) {
+        _cachedMetadata = json.decode(response.body);
+        return _cachedMetadata!;
+      }
+    } catch (e) {
+      print("CollegeSport Metadata Error: $e");
+    }
+    return {'Sports': [], 'Competitions': [], 'GradesPerComp': {}, 'OrgsPerComp': {}};
+  }
+}

--- a/lib/services/rugbyunion_api_service.dart
+++ b/lib/services/rugbyunion_api_service.dart
@@ -1,0 +1,155 @@
+// lib/services/rugbyunion_api_service.dart
+
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../models.dart';
+
+class RugbyUnionApiService {
+  static final RugbyUnionApiService _instance = RugbyUnionApiService._internal();
+  factory RugbyUnionApiService() => _instance;
+  RugbyUnionApiService._internal();
+
+  static const String _proxyBaseUrl = "http://localhost:9999";
+  static const String _rugbyUnionApiUrl = "https://rugby-au-cms.graphcdn.app/";
+  
+  static final Map<String, String> _headers = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  };
+
+  Map<String, dynamic>? _cachedRugbyUnionData;
+  String? _cachedRugbyBuildId;
+
+  Future<List<Fixture>> getFixtures({DateTimeRange? dateRange}) async {
+    final sacredHeartEntityId = await _getSacredHeartEntityId();
+    if (sacredHeartEntityId == null) return [];
+
+    final fixturesPayload = _getFixturesPayload(sacredHeartEntityId, "fixtures");
+    final resultsPayload = _getFixturesPayload(sacredHeartEntityId, "results");
+
+    try {
+      final responses = await Future.wait([
+        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(fixturesPayload)),
+        http.post(Uri.parse(_rugbyUnionApiUrl), headers: _headers, body: json.encode(resultsPayload)),
+      ]);
+
+      List<Fixture> allRugbyFixtures = [];
+      const String sacredHeartName = "Sacred Heart College";
+
+      for (final response in responses) {
+        if (response.statusCode == 200) {
+          final decodedData = json.decode(response.body);
+          final List<dynamic> fixtureData = decodedData['data']?['getEntityFixturesAndResults'] ?? [];
+          
+          final sacredHeartFixtures = fixtureData
+            .where((data) {
+                final homeTeamName = data['homeTeam']?['name'] as String? ?? '';
+                final awayTeamName = data['awayTeam']?['name'] as String? ?? '';
+                return homeTeamName.contains(sacredHeartName) || awayTeamName.contains(sacredHeartName);
+            })
+            .map((data) => Fixture.fromRugbyUnionJson(data));
+
+          allRugbyFixtures.addAll(sacredHeartFixtures);
+        }
+      }
+
+      if (dateRange != null) {
+        return allRugbyFixtures.where((f) {
+          try {
+            final fixtureDate = DateTime.parse(f.dateTime);
+            return fixtureDate.isAfter(dateRange.start.subtract(const Duration(days: 1))) && fixtureDate.isBefore(dateRange.end.add(const Duration(days: 1)));
+          } catch(e) { return false; }
+        }).toList();
+      }
+      
+      return allRugbyFixtures;
+
+    } catch (e) {
+      print("Rugby Union Fixtures Error: $e");
+    }
+    return [];
+  }
+
+  Future<List<StandingsTable>> getStandings(String competitionId) async {
+    final payload = {
+      "operationName": "CompLadderQuery",
+      "variables": {"comp": {"id": competitionId, "sourceType": "2"}},
+      "query": "query CompLadderQuery(\$comp: CompInput) {\n  compLadder(comp: \$comp) {\n    ...LadderCard_ladder\n    __typename\n  }\n}\n\nfragment LadderCard_ladder on Ladder {\n  id\n  hasPools\n  ladderPools {\n    id\n    poolName\n    teams {\n      ...LadderCard_ladderTeam\n      __typename\n    }\n    __typename\n  }\n  sortingOptions\n  overallSort\n  __typename\n}\n\nfragment LadderCard_ladderTeam on LadderTeam {\n  active\n  bonusPoints3T\n  bonusPoints4T\n  bonusPoints7P\n  byes\n  crest\n  id\n  matchWinRatio\n  matchesDrawn\n  matchesLost\n  matchesPlayed\n  matchesWon\n  name\n  numberForfeitsLoss\n  numberForfeitsWin\n  numberOfForfeits\n  pointsADJ\n  pointsAgainst\n  pointsAgainstADJ\n  pointsDifference\n  pointsFor\n  pointsForADJ\n  pointsRatio\n  position\n  scoreRatio\n  totalBonusPoints\n  totalMatchPoints\n  totalTries\n  tryDifference\n  __typename\n}"
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(_rugbyUnionApiUrl),
+        headers: _headers,
+        body: json.encode(payload),
+      );
+
+      if (response.statusCode == 200) {
+        final decodedData = json.decode(response.body);
+        final ladderData = decodedData['data']?['compLadder'];
+        if (ladderData != null) {
+          return [StandingsTable.fromRugbyUnionJson(ladderData)];
+        }
+      }
+    } catch (e) {
+      print("Rugby Union Standings Error: $e");
+    }
+    return [];
+  }
+
+  Future<int?> _getSacredHeartEntityId() async {
+    final rugbyData = await _getRugbyUnionData();
+    final clubs = rugbyData['pageProps']?['clubs'] as List<dynamic>? ?? [];
+    final sacredHeartClub = clubs.firstWhere((c) => c['name'] == 'Sacred Heart College', orElse: () => null);
+    if (sacredHeartClub == null) return null;
+    return int.tryParse(sacredHeartClub['id'] ?? '');
+  }
+
+  Future<String> _getRugbyUnionBuildId() async {
+    if (_cachedRugbyBuildId != null) return _cachedRugbyBuildId!;
+
+    final url = Uri.parse("$_proxyBaseUrl/aucklandrugby/fixtures-and-results");
+    try {
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        final body = response.body;
+        final pattern = RegExp(r'"buildId":"([^"]+)"');
+        final match = pattern.firstMatch(body);
+        if (match != null && match.group(1) != null) {
+          _cachedRugbyBuildId = match.group(1);
+          print('Successfully fetched new Rugby Union Build ID: $_cachedRugbyBuildId');
+          return _cachedRugbyBuildId!;
+        }
+      }
+      throw Exception('Failed to find Rugby Union buildId in HTML response.');
+    } catch (e) {
+      print('Error fetching Rugby Union build ID: $e');
+      return 'EYwFsoHsI7WQjAopi5hIv'; // Fallback to last known working ID
+    }
+  }
+
+  Future<Map<String, dynamic>> _getRugbyUnionData() async {
+    if (_cachedRugbyUnionData != null) return _cachedRugbyUnionData!;
+    try {
+      final buildId = await _getRugbyUnionBuildId();
+      final rugbyUnionDataUrl = "$_proxyBaseUrl/aucklandrugby/_next/data/$buildId/fixtures-results.json";
+      final response = await http.get(Uri.parse(rugbyUnionDataUrl));
+      if (response.statusCode == 200) {
+        _cachedRugbyUnionData = json.decode(response.body);
+        return _cachedRugbyUnionData!;
+      }
+    } catch (e) {
+      print("Rugby Union Data Error: $e");
+    }
+    return {'pageProps': {'competitions': [], 'clubs': []}};
+  }
+
+  Map<String, dynamic> _getFixturesPayload(int entityId, String type) {
+    return {
+      "operationName": "EntityFixturesAndResults",
+      "variables": {"season":"","comps":[],"teams":[],"type": type,"skip":0,"limit":100,"entityId":entityId,"entityType":"club"},
+      "query": "query EntityFixturesAndResults(\$entityId: Int, \$entityType: String, \$season: String, \$comps: [CompInput], \$teams: [String], \$type: String, \$skip: Int, \$limit: Int) {\n  getEntityFixturesAndResults(\n    season: \$season\n    comps: \$comps\n    teams: \$teams\n    entityId: \$entityId\n    entityType: \$entityType\n    type: \$type\n    limit: \$limit\n    skip: \$skip\n  ) {\n    ...Fixtures_fixture\n    __typename\n  }\n}\n\nfragment Fixtures_fixture on FixtureItem {\n  id\n  compId\n  compName\n  dateTime\n  group\n  isLive\n  isBye\n  round\n  roundType\n  roundLabel\n  season\n  status\n  venue\n  sourceType\n  matchLabel\n  homeTeam {\n    ...Fixtures_team\n    __typename\n  }\n  awayTeam {\n    ...Fixtures_team\n    __typename\n  }\n  fixtureMeta {\n    ...Fixtures_meta\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_team on Team {\n  id\n  name\n  teamId\n  score\n  crest\n  __typename\n}\n\nfragment Fixtures_meta on Fixture {\n  id\n  ticketURL\n  ticketsAvailableDate\n  isSoldOut\n  radioURL\n  radioStart\n  radioEnd\n  streamURL\n  streamStart\n  streamEnd\n  broadcastPartners {\n    ...Fixtures_broadcastPartners\n    __typename\n  }\n  __typename\n}\n\nfragment Fixtures_broadcastPartners on BroadcastPartner {\n  id\n  name\n  link\n  photoId\n  __typename\n}"
+    };
+  }
+}

--- a/lib/upcoming_fixture_widget.dart
+++ b/lib/upcoming_fixture_widget.dart
@@ -98,8 +98,8 @@ class _UpcomingFixtureWidgetState extends State<UpcomingFixtureWidget> {
           builder: (BuildContext context, StateSetter setDialogState) {
             
             final sacredHeartTeams = _allFixtures
-                .where((f) => _filters.sport == null || f.sport == _filters.sport)
-                .map((f) => f.homeSchool == "Sacred Heart College (Auckland)" ? f.homeTeam : f.awayTeam)
+                .where((f) => (_filters.sport == null || f.sport == _filters.sport) && (f.homeSchool.contains("Sacred Heart College") || f.awaySchool.contains("Sacred Heart College")))
+                .map((f) => f.homeSchool.contains("Sacred Heart College") ? f.homeTeam : f.awayTeam)
                 .toSet().toList()..sort();
 
             return AlertDialog(
@@ -219,9 +219,8 @@ class _UpcomingFixtureWidgetState extends State<UpcomingFixtureWidget> {
                 ),
                 TextButton(
                   onPressed: () {
-                    // Re-fetch with new date range, then filter client-side
                     _fetchFixtures(); 
-                    setState((){}); // Apply client-side filters immediately
+                    setState((){});
                     Navigator.of(context).pop();
                   },
                   child: const Text('Apply'),
@@ -346,8 +345,8 @@ class _CompactFixtureCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const String ourSchool = "Sacred Heart College (Auckland)";
-    final ourTeam = fixture.homeSchool == ourSchool ? fixture.homeTeam : fixture.awayTeam;
-    final opponentSchool = fixture.homeSchool == ourSchool ? fixture.awaySchool : fixture.homeSchool;
+    final ourTeam = fixture.homeSchool.contains("Sacred Heart College") ? fixture.homeTeam : fixture.awayTeam;
+    final opponentSchool = fixture.homeSchool.contains("Sacred Heart College") ? fixture.awaySchool : fixture.homeSchool;
     final homeScore = fixture.homeScore ?? '-';
     final awayScore = fixture.awayScore ?? '-';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -96,6 +96,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_parser:
     dependency: transitive
     description:
@@ -248,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  shelf_router:
+    dependency: "direct dev"
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  shelf: ^1.4.1
+  shelf_proxy: ^1.0.4
+  shelf_router: ^1.1.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
**Description:**
This feature integrates the Auckland Rugby Union API as a second data source and refactors the API service layer for improved scalability and maintainability.

**Key Features & Fixes:**
- **Multi-Source Integration**: The app now fetches and displays unified data for fixtures, results, and standings from both the CollegeSport and Auckland Rugby Union APIs.
- **Dynamic URL Fetching**: Implemented a robust solution to dynamically find the correct data URL for the Auckland Rugby API by scraping the live build ID, preventing failures when the source website is updated.
- **Enhanced Geocoding**: For fixtures without coordinates (from the Rugby API), the app now geocodes the venue name using the OpenStreetMap API, providing a map and directions for users. The search is prioritized for the Auckland, NZ region to ensure accuracy.
- **Service Layer Refactoring**: The original `ApiService` has been refactored into an orchestrator. All source-specific logic is now isolated into dedicated classes (`CollegeSportApiService`, `RugbyUnionApiService`), following the separation of concerns principle. This makes the codebase cleaner and easier to extend with new data sources in the future.
- **CORS Proxy**: A multi-domain CORS proxy server was implemented to handle requests to both external APIs during local web development, resolving all cross-origin errors.
- **Dependencies**: Added `shelf`, `shelf_proxy`, and `shelf_router` to `dev_dependencies` to support the proxy server.
